### PR TITLE
Refactored the equality tests to use parameter testing

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,6 +3,9 @@ lazy val root = (project in file(".")).
     name := "compliant",
     version := "0.0.1",
     scalaVersion := "2.11.8",
-    libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.1",
-    libraryDependencies += "org.scalactic" %% "scalactic" % "3.0.1"
+    libraryDependencies ++= Seq(
+      "org.scalatest" %% "scalatest" % "3.0.1" % Test,
+      "org.scalactic" %% "scalactic" % "3.0.1" % Test,
+      "org.scalacheck" %% "scalacheck" % "1.13.4" % Test
+    )
   )


### PR DESCRIPTION
We need more tests to properly cover all of the equality cases.
I've refactored the tests to use parameter testing to make it easier to add more cases.
I've added several passing test cases,
and failing cases that require changes to the code.