### PR TITLE
Cleaner Comparison Logic and Improved Prerelease Comparison

### DIFF
--- a/src/main/scala/SemanticVersion.scala
+++ b/src/main/scala/SemanticVersion.scala
@@ -35,26 +35,28 @@ class SemanticVersion(val versionString: String) extends Ordered[SemanticVersion
   }
 
   def compare(that: SemanticVersion) = {
-    if (this == that) {
-      0
-    } else if (this.majorVersion > that.majorVersion) {
-      1
-    } else if (this.majorVersion == that.majorVersion) {
-      if (this.minorVersion > that.minorVersion) {
+    val majorVersionDiff = this.majorVersion.toInt - that.majorVersion.toInt
+    val minorVersionDiff = this.minorVersion.toInt - that.minorVersion.toInt
+    val patchVersionDiff = this.patchVersion.toInt - that.patchVersion.toInt
+    val prereleaseVersionDiff =
+      if (this.prerelease.isEmpty && !that.prerelease.isEmpty) {
         1
-      } else if (this.minorVersion == that.minorVersion) {
-        if (this.patchVersion > that.patchVersion) {
-          1
-        } else if (this.patchVersion == that.patchVersion && this.prerelease > that.prerelease) {
-          1
-        } else {
-          -1 // major, minor, patch version are same, prerelease is less
-        }
+      } else if (!this.prerelease.isEmpty && that.prerelease.isEmpty) {
+        -1
       } else {
-        -1 // major version is same, and minor version is less
+        this.prerelease.compare(that.prerelease)
       }
+
+    if (this.versionStringWithoutBuildMetadata == that.versionStringWithoutBuildMetadata) {
+      0
+    } else if (majorVersionDiff != 0) {
+      majorVersionDiff
+    } else if (minorVersionDiff != 0) {
+      minorVersionDiff
+    } else if (patchVersionDiff != 0) {
+      patchVersionDiff
     } else {
-      -1 // major version is less
+      prereleaseVersionDiff
     }
   }
 }

--- a/src/main/scala/SemanticVersion.scala
+++ b/src/main/scala/SemanticVersion.scala
@@ -1,6 +1,7 @@
 package compliant
 
 import scala.util.matching.Regex
+import scala.collection.mutable.ListBuffer
 
 object SemanticVersion {
 
@@ -38,14 +39,7 @@ class SemanticVersion(val versionString: String) extends Ordered[SemanticVersion
     val majorVersionDiff = this.majorVersion.toInt - that.majorVersion.toInt
     val minorVersionDiff = this.minorVersion.toInt - that.minorVersion.toInt
     val patchVersionDiff = this.patchVersion.toInt - that.patchVersion.toInt
-    val prereleaseVersionDiff =
-      if (this.prerelease.isEmpty && !that.prerelease.isEmpty) {
-        1
-      } else if (!this.prerelease.isEmpty && that.prerelease.isEmpty) {
-        -1
-      } else {
-        this.prerelease.compare(that.prerelease)
-      }
+    val prereleaseVersionDiff = this.prereleaseCompare(that)
 
     if (this.versionStringWithoutBuildMetadata == that.versionStringWithoutBuildMetadata) {
       0
@@ -59,4 +53,126 @@ class SemanticVersion(val versionString: String) extends Ordered[SemanticVersion
       prereleaseVersionDiff
     }
   }
+
+  def prereleaseCompare(that: SemanticVersion): Int = {
+    if (this.prerelease.isEmpty && !that.prerelease.isEmpty) {
+      return 1
+    } else if (!this.prerelease.isEmpty && that.prerelease.isEmpty) {
+      return -1
+    } else {
+      val thisArray = Chunkify.chunkify(this.prerelease)
+      val thatArray = Chunkify.chunkify(that.prerelease)
+      var currentDiff = 0
+      var currentIndex = 0
+
+      while (currentDiff == 0 && currentIndex < thisArray.length) {
+        val currentThis = thisArray(currentIndex)
+        val currentThat = thatArray(currentIndex)
+
+        // TODO: Find a way to do this that doesn't abuse
+        // exceptions
+        try {
+          currentDiff = currentThis.toInt.compare(currentThat.toInt)
+        } catch {
+          case e: Exception =>
+            currentDiff = currentThis.compare(currentThat)
+        }
+
+        currentIndex = currentIndex + 1
+      }
+
+      // TODO: Find a way to not use return statements
+      if (currentDiff == 0) {
+        if (thisArray.length == thatArray.length) {
+          return 0
+        } else if (thisArray.length < thatArray.length) {
+          return 1
+        } else {
+          return -1
+        }
+      } else {
+        return currentDiff
+      }
+    }
+  }
+
+}
+
+// Helper functions for chunking prerelease strings
+// TODO: Consider moving this to another file
+object Chunkify {
+
+  def chunkify(string: String) = {
+    var chunks = new ListBuffer[String]()
+    var currentChunk = new StringBuilder
+    var currentChunkType = ""
+    var i = 0
+
+    while (i < string.length) {
+      var c = string(i)
+
+      val thisChunkType = {
+        if (isDigit(c.toString)) {
+          "digit"
+        } else if (isAlpha(c.toString)) {
+          "alpha"
+        } else if (isPunctuation(c.toString)) {
+          "punctuation"
+        } else {
+          "unknown"
+        }
+      }
+
+      // Beginning of the string or beginning of a new chunk
+      if (currentChunkType == "" || currentChunkType == thisChunkType) {
+        currentChunk += c
+        currentChunkType = thisChunkType
+      } else {
+        chunks += currentChunk.toString
+        currentChunk = new StringBuilder
+        currentChunk += c
+        currentChunkType = thisChunkType
+      }
+
+      // Make sure to append the final chunk when
+      // we reach the end of the string
+      if (i == string.length - 1) {
+        chunks += currentChunk.toString
+      }
+
+      i += 1
+    }  // end string.map
+
+    chunks.toList
+  }
+
+  def isDigit(s: String) = {
+    if (Array("0", "1", "2", "3", "4", "5", "6", "7", "8", "9").contains(s)) {
+      true
+    } else {
+      false
+    }
+  }
+
+  def isPunctuation(s: String) = {
+    if (Array(".", "-", "+").contains(s)) {
+      true
+    } else {
+      false
+    }
+  }
+
+  def isAlpha(s: String) = {
+    val alphaArray = Array(
+      "a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l",
+      "m", "n", "o", "p", "q", "r", "s", "t", "u", "v", "w", "x",
+      "y", "z")
+
+    if (alphaArray.contains(s.toLowerCase)) {
+      true
+    } else {
+      false
+    }
+  }
+
 }

--- a/src/test/scala/SemanticVersionSpec.scala
+++ b/src/test/scala/SemanticVersionSpec.scala
@@ -69,17 +69,17 @@ class SemanticVersionSpec extends CompliantSpecBase with PropertyChecks {
         ("lesser", "greater"),
         ("1.0.0", "2.0.0"),
         ("1.0.0", "10.0.0"),
-        // TODO: ("2.0.0", "10.0.0"),
+        ("2.0.0", "10.0.0"),
         ("0.1.0", "0.2.0"),
         ("0.1.0", "0.10.0"),
-        // TODO: ("0.2.0", "0.10.0"),
+        ("0.2.0", "0.10.0"),
         ("0.0.1", "0.0.2"),
         ("0.0.1", "0.0.10"),
-        // TODO: ("0.0.2", "0.0.10"),
+        ("0.0.2", "0.0.10"),
         ("1.0.0-alpha", "1.0.0-beta"),   // pre-release versions
         ("1.1.0-20160605", "1.1.0-alpha"),  // numeric identifiers have lower precedence
-        ("1.0.0-20170109", "1.0.0-20170110")
-        // TODO: ("1.0.0-2", "1.0.0-10")
+        ("1.0.0-20170109", "1.0.0-20170110"),
+        ("1.0.0-2", "1.0.0-10")
       )
 
       "properly determine ordering for inequal versions" in {


### PR DESCRIPTION
Improved prerelease comparisons

- Added helper methods to split alphanumeric strings into alpha and numeric chunks.
- Added helper method to compare arrays of alpha and numeric chunks